### PR TITLE
79

### DIFF
--- a/site/components/CategoryItem/CategoryItem.module.scss
+++ b/site/components/CategoryItem/CategoryItem.module.scss
@@ -2,6 +2,9 @@
 @use '../../styles/mixins' as *;
 .CategoryItem {
     padding: 2rem;
+	@media(max-width: 25.875rem) {
+		padding: 2rem 0;
+	}
     &__item {
 		display: block;
 		width: 100%;

--- a/site/components/Row/Row.module.scss
+++ b/site/components/Row/Row.module.scss
@@ -28,7 +28,7 @@
 .Col {
 	flex: 1 0 auto;
 	&[class*=🔥col-] {
-		flex-grow: 0;
+		flex-grow: 1;
 		flex-shrink: 1;
 	}
 }

--- a/site/pages/home/Home.module.scss
+++ b/site/pages/home/Home.module.scss
@@ -2,6 +2,9 @@
 @use '../../styles/mixins' as *;
 .Home {
 	&__hero {
+		@include maxq(25rem) {
+			padding-top: 2rem;
+		}
 		&__text {
 			h1, p {
 				color:$white;
@@ -9,17 +12,25 @@
 			h1 {
 				font-size: 5rem;
 				@include maxq(48rem) {
-					font-size: 4rem;
+					font-size: 3rem;
+					line-height: 1;
 				}
 			}
 			p {
 				font-size: 2rem;
 				line-height: 1.25;
 				font-weight: bold;
+				@include maxq(48rem) {
+					font-size: 1.5rem;
+				}
 			}
 		}
 		&__welcome_card {
 			border-radius: 0.5rem;
+			@include maxq(48rem) {
+				width: 100%;
+			}
+			
 		}
 	}
 	&__actions {
@@ -27,8 +38,10 @@
 		background-color: $grey;
 		max-width: 75rem;
 		width: 95%;
-		border-radius: 0 0.5rem 0.5rem 0;
+		border-radius: 0.5rem;
 		padding: 1rem;
+		margin-left: auto;
+		margin-right: auto;
 		p {
 			margin-bottom: 0;
 		}

--- a/site/pages/index.tsx
+++ b/site/pages/index.tsx
@@ -57,7 +57,7 @@ const Home: NextPage = (): any => (
 		</Section>
 		<div className={styles.Home__actions}>
 			<Container>
-				<Row>
+				<Row columns={{ xs: [12, 12, 12], md: [3, 3, 3] }}>
 					<p>
 						850 S Bluff Street
 						<br />

--- a/site/styles/_typography.scss
+++ b/site/styles/_typography.scss
@@ -1,6 +1,6 @@
 @use './colors' as *;
 @use './mixins' as *;
-@import url('https://fonts.googleapis.com/css2?family=Kanit:ital,wght@0,500;0,900;1,500;1,900&family=Montserrat:ital,wght@0,500;0,800;1,500;1,700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Kanit:ital,wght@0,500;0,700;1,500;1,700&family=Montserrat:ital,wght@0,500;0,800;1,500;1,700&display=swap');
 * {
 	font-family: 'Montserrat', sans-serif;
 }


### PR DESCRIPTION
Closes issue #79 
[79: Category Item: Adjust mobile padding for the x axis](https://github.com/christoph-codes/green-iguana-mex/commit/18f884d82f678eef81698926faa92d69baf6d28f)

@[christoph-codes](https://github.com/christoph-codes/green-iguana-mex/commits?author=christoph-codes)
christoph-codes committed 3 hours ago
 
[79: Add flex grow to the column within a row element to span the entire column](https://github.com/christoph-codes/green-iguana-mex/commit/98811c75d45978c5353a3fe465680cd275c99f04) 

@[christoph-codes](https://github.com/christoph-codes/green-iguana-mex/commits?author=christoph-codes)
christoph-codes committed 3 hours ago
 
[79: Home page: Adjust actions panel to be centered in the container instead of off kilter](https://github.com/christoph-codes/green-iguana-mex/commit/ed0da30441ea169e5eed2d976c8e5708ed8027d3) 

@[christoph-codes](https://github.com/christoph-codes/green-iguana-mex/commits?author=christoph-codes)
christoph-codes committed 3 hours ago
 
[79: Home Hero: Adjust font sizes for mobile to be more legible](https://github.com/christoph-codes/green-iguana-mex/commit/415d46852a844cb66e2149838249fb22878b4a27)

@[christoph-codes](https://github.com/christoph-codes/green-iguana-mex/commits?author=christoph-codes)
christoph-codes committed 3 hours ago
 
[79: Typography: Remove 900 font weight from global css import](https://github.com/christoph-codes/green-iguana-mex/commit/f036a42d8ef3d141e3ec2129aacdd903f0273146)